### PR TITLE
Fixed issue causing MWException on page load.

### DIFF
--- a/Markdown.php
+++ b/Markdown.php
@@ -63,6 +63,8 @@ class MarkdownExtension
             $out->addStyle($wgMarkdownHighlightCss);
             $out->addInlineScript('hljs.initHighlightingOnLoad();');
         }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
This is the exception message that was happening:
Original exception: exception 'MWException' with message 'Detected bug in an extension! Hook MarkdownExtension::onBeforePageDisplay failed to return a value; should return true to continue hook processing or false to abort.' in /srv/http/mediawiki/includes/Hooks.php:284

This fixes #3.