### PR TITLE
Ensure erroneous extra paragraphs are removed

### DIFF
--- a/Markdown.php
+++ b/Markdown.php
@@ -137,6 +137,7 @@ class MarkdownExtension
         // Post-Markdown wiki parsing
         $html = $parser->formatHeadings($html, $text);
         $html = $parser->doMagicLinks($html);
+        $html = $parser->stripOuterParagraph($html);
 
         return $html;
     }


### PR DESCRIPTION
Avoid additional `<p>` tags around every bit of rendered wikitext.

Closes #15.